### PR TITLE
fix: docker cp should use /. in from directory in order to overwrite

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -61,15 +61,15 @@ docker-compose -f docker-compose.yml $operator $cv $app up -d
 echo 'Docker containers are up'
 
 if [[ -n "$operator" ]]; then
-  docker cp ../operator e2e_operator_1:/app && docker exec e2e_operator_1 sh -c "node wait-for-postgres && npm run migrate up" && docker exec -d e2e_operator_1 npm start
+  docker cp ../operator/. e2e_operator_1:/app && docker exec e2e_operator_1 sh -c "node wait-for-postgres && npm run migrate up" && docker exec -d e2e_operator_1 npm start
 fi
 
 if [[ -n "$cv" ]]; then
-  docker cp ../example-cv e2e_cv_1:/app && docker exec e2e_cv_1 npm run build && docker exec -d e2e_cv_1 npm start
+  docker cp ../example-cv/. e2e_cv_1:/app && docker exec e2e_cv_1 npm run build && docker exec -d e2e_cv_1 npm start
 fi
 
 if [[ -n "$app" ]]; then
-  docker cp ../app e2e_app_1:/app && docker exec e2e_app_1 npm run e2e:build && docker exec -d e2e_app_1 npm run e2e:start
+  docker cp ../app/. e2e_app_1:/app && docker exec e2e_app_1 npm run e2e:build && docker exec -d e2e_app_1 npm run e2e:start
 fi
 
 echo 'Sleep 3 seconds'


### PR DESCRIPTION
Without /. at the end of the "from"-directory docker cp will copy that directory into the "to"-directory rather than overwrite it as the intended behavior.